### PR TITLE
[Bug fix] - Variable referenced before assignment

### DIFF
--- a/answerfile.py
+++ b/answerfile.py
@@ -93,7 +93,7 @@ class Answerfile:
         results = {}
         if self.operation == 'installation':
             install_type = getStrAttribute(self.top_node, ['mode'], default = 'fresh')
-            results['netinstall-gpg-check'] = getBoolAttribute(self.top_node, ['netinstall-gpg-check'], default = True)
+            
             if install_type == "fresh":
                 results = self.parseFreshInstall()
             elif install_type == "reinstall":
@@ -103,6 +103,7 @@ class Answerfile:
             else:
                 raise AnswerfileException, "Unknown mode, %s" % install_type
 
+            results['netinstall-gpg-check'] = getBoolAttribute(self.top_node, ['netinstall-gpg-check'], default = True)
             results.update(self.parseCommon())
         elif self.operation == 'restore':
             results = self.parseRestore()

--- a/answerfile.py
+++ b/answerfile.py
@@ -90,6 +90,7 @@ class Answerfile:
 
     def processAnswerfile(self):
         xelogging.log("Processing XML answerfile for %s." % self.operation)
+        results = {}
         if self.operation == 'installation':
             install_type = getStrAttribute(self.top_node, ['mode'], default = 'fresh')
             results['netinstall-gpg-check'] = getBoolAttribute(self.top_node, ['netinstall-gpg-check'], default = True)


### PR DESCRIPTION
The installation will fail while using an answefile_generator script. The results variable is referenced before assignment.