### PR TITLE
Fix Ryzen boot problems

### DIFF
--- a/bootloader/grub.cfg
+++ b/bootloader/grub.cfg
@@ -17,31 +17,31 @@ insmod ext2
 set timeout=5
 
 menuentry "install" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz xencons=hvc console=hvc0 console=tty0
     module2 /install.img
 }
 
 menuentry "no-serial" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M console=vga
     module2 /boot/vmlinuz console=tty0
     module2 /install.img
 }
 
 menuentry "safe" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg iommu=off max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg iommu=off max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep
     module2 /boot/vmlinuz xencons=hvc console=hvc0 console=tty0
     module2 /install.img
 }
 
 menuentry "multipath" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 device_mapper_multipath=enabled
     module2 /install.img
 }
 
 menuentry "shell" {
-    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga
+    multiboot2 /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga
     module2 /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 bash-shell
     module2 /install.img
 }

--- a/bootloader/isolinux.cfg
+++ b/bootloader/isolinux.cfg
@@ -8,22 +8,22 @@ F2 pg_help
 
 LABEL install
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 --- /install.img
 LABEL no-serial
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M console=vga --- /boot/vmlinuz console=tty0 --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M console=vga --- /boot/vmlinuz console=tty0 --- /install.img
 LABEL safe
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg iommu=off max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg iommu=off max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 --- /install.img
 LABEL multipath
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 device_mapper_multipath=enabled --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 device_mapper_multipath=enabled --- /install.img
 LABEL shell
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 bash-shell --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 bash-shell --- /install.img
 LABEL common-criteria-prep
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:8192M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 cc-preparations --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-16 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 cc-preparations --- /install.img
 
 LABEL memtest
 	KERNEL memtest


### PR DESCRIPTION
As noted in https://github.com/xcp-ng/xcp/issues/206 a memory setting of 8GB halts the boot sequence and causes USB issues. The workaround was to set the maximum memory to 2GB instead, which this pull request does. 