### PR TITLE
Include mmcblk-devices in disk selection

### DIFF
--- a/disktools.py
+++ b/disktools.py
@@ -488,7 +488,7 @@ def diskDevice(partitionDevice):
 
 def determineMidfix(device):
     DISK_PREFIX = '/dev/'
-    P_STYLE_DISKS = [ 'cciss', 'ida', 'rd', 'sg', 'i2o', 'amiraid', 'iseries', 'emd', 'carmel', 'mapper/', 'nvme', 'md' ]
+    P_STYLE_DISKS = [ 'cciss', 'ida', 'rd', 'sg', 'i2o', 'amiraid', 'iseries', 'emd', 'carmel', 'mapper/', 'nvme', 'md', 'mmcblk' ]
     PART_STYLE_DISKS = [ 'disk/by-id' ]
 
     for key in P_STYLE_DISKS:

--- a/diskutil.py
+++ b/diskutil.py
@@ -130,6 +130,9 @@ for major in range(48, 56):
 # /dev/md    : md has major 9: each device has 15 minors)
 disk_nodes += [ (9, x * 16) for x in range(16) ]
 
+# /dev/mmcblk: mmcblk has major 179, each device usually (per kernel) has 7 minors
+disk_nodes += [ (179, x * 8) for x in range(32) ]
+
 def getDiskList():
     # read the partition tables:
     parts = open("/proc/partitions")


### PR DESCRIPTION
See https://xcp-ng.org/forum/post/19818
This has been tested on the same platform as mentioned in the forum post.