### PR TITLE
XCP-ng-8.1 host installer patch for showing kernel alt warning

### DIFF
--- a/tui/__init__.py
+++ b/tui/__init__.py
@@ -18,6 +18,7 @@ import traceback
 import constants
 import sys
 from xcp import logger
+import platform
 
 screen = None
 help_pad = [33, 17, 16]
@@ -38,7 +39,7 @@ To advance to the next screen navigate to the Ok button and press Enter or press
 def init_ui():
     global screen
     screen = SnackScreen()
-    screen.drawRootText(0, 0, "Welcome to %s - Version %s" % (PRODUCT_BRAND or PLATFORM_NAME, PRODUCT_VERSION or PLATFORM_VERSION))
+    screen.drawRootText(0, 0, "Welcome to %s - Version %s (Kernel %s)" % (PRODUCT_BRAND or PLATFORM_NAME, PRODUCT_VERSION or PLATFORM_VERSION, platform.release()))
     if PRODUCT_BRAND:
         if len(COPYRIGHT_YEARS) > 0:
             screen.drawRootText(0, 1, "Copyright (c) %s %s" % (COPYRIGHT_YEARS, COMPANY_NAME_LEGAL))

--- a/tui/installer/__init__.py
+++ b/tui/installer/__init__.py
@@ -141,6 +141,7 @@ def runMainSequence(results, ram_warning, vt_warning, suppress_extra_cd_dialog):
         results['preserve-settings'] = False
 
     seq = [
+	Step(uis.kernel_warning),
         Step(uis.welcome_screen),
         Step(uis.eula_screen),
         Step(uis.hardware_warnings,

--- a/tui/installer/screens.py
+++ b/tui/installer/screens.py
@@ -37,6 +37,8 @@ import tui.progress
 import driver
 import tui.fcoe
 
+import os
+
 MY_PRODUCT_BRAND = PRODUCT_BRAND or PLATFORM_NAME
 
 def selectDefault(key, entries):
@@ -47,6 +49,23 @@ def selectDefault(key, entries):
         if key == k:
             return text, k
     return None
+
+# kernel-alt warning
+def kernel_warning(key):
+    if util.isKernelAlt():
+        button = snackutil.ButtonChoiceWindowEx(
+            tui.screen,
+            "Kernel-alt",
+            "You chose to run kernel-alt.\n\n\
+             It is an alternate kernel to base with upstream patches and\n\
+             latest drivers but it is not as well tested as base kernel.",
+            ['Ok', 'Reboot'], width=70)
+
+        if button == 'ok' or button is None:
+            return True
+        else:
+            os.system("reboot")
+    return True
 
 # welcome screen:
 def welcome_screen(answers):

--- a/util.py
+++ b/util.py
@@ -374,6 +374,10 @@ def isNetInstall():
     with open('/proc/cmdline') as f:
         return 'netinstall' in f.read().split(' ')
 
+def isKernelAlt():
+    with open('/proc/cmdline') as f:
+        return 'kernel-alt' in f.read().split(' ')
+
 def getLocalTime(timezone=None):
     if timezone:
         os.environ['TZ'] = timezone


### PR DESCRIPTION
Partial patch to address https://github.com/xcp-ng/xcp/issues/340 

- [ ] modify the install so that it displays a notice about kernels if booted from install-alt (need to update the text)