### PR TITLE
Copy `grubx64.efi` into `EFI/boot/`

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1290,9 +1290,8 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 
     # Add fallback for when all boot entries fail (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
-    util.runCmd2(["chroot", mounts['root'], "/usr/bin/mkdir", "-p" "/boot/efi/EFI/boot"])
-    util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/gcdx64.efi", "/boot/efi/EFI/boot/bootx64.efi"])
-    util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/grub.cfg", "/boot/efi/EFI/boot/grub.cfg"])
+    util.runCmd2(["chroot", mounts['root'], "/usr/bin/mkdir", "-p", "/boot/efi/EFI/boot"])
+    util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/grubx64.efi", "/boot/efi/EFI/boot/bootx64.efi"])
 
 def installGrub2(mounts, disk, force):
     if force:

--- a/backend.py
+++ b/backend.py
@@ -1289,6 +1289,11 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 
+    # Add fallback EFI boot files for some systems
+    util.runCmd2(["chroot", mounts['root'], "/usr/bin/mkdir", "-p" "/boot/efi/EFI/boot"])
+    util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/gcdx64.efi", "/boot/efi/EFI/boot/bootx64.efi"])
+    util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/grub.cfg", "/boot/efi/EFI/boot/grub.cfg"])
+
 def installGrub2(mounts, disk, force):
     if force:
         rc, err = util.runCmd2(["chroot", mounts['root'], "/usr/sbin/grub-install", "--target=i386-pc", "--force", disk], with_stderr=True)

--- a/backend.py
+++ b/backend.py
@@ -1289,7 +1289,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 
-    # Add fallback EFI boot files for some UEFI firmwares that do not follow the UEFI specs fully
+    # Add fallback for when all boot entries fail (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/mkdir", "-p" "/boot/efi/EFI/boot"])
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/gcdx64.efi", "/boot/efi/EFI/boot/bootx64.efi"])
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/grub.cfg", "/boot/efi/EFI/boot/grub.cfg"])

--- a/backend.py
+++ b/backend.py
@@ -1289,7 +1289,7 @@ def setEfiBootEntry(mounts, disk, boot_partnum, install_type, branding):
                             "-d", disk, "-p", str(boot_partnum)], with_stderr=True)
     check_efibootmgr_err(rc, err, install_type, "Failed to run efibootmgr")
 
-    # Add fallback EFI boot files for some systems
+    # Add fallback EFI boot files for some UEFI firmwares that do not follow the UEFI specs fully
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/mkdir", "-p" "/boot/efi/EFI/boot"])
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/gcdx64.efi", "/boot/efi/EFI/boot/bootx64.efi"])
     util.runCmd2(["chroot", mounts['root'], "/usr/bin/cp", "/boot/efi/EFI/xenserver/grub.cfg", "/boot/efi/EFI/boot/grub.cfg"])


### PR DESCRIPTION
Some firmware needs to have a fallback efi binary in the EFI/boot directory and
will fail to boot if not.
See: https://xcp-ng.org/forum/topic/4690/host-not-booting-after-install-uefi/

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>